### PR TITLE
Replace use of alignment_baseline with dominant_baseline

### DIFF
--- a/src/charts/bar.rs
+++ b/src/charts/bar.rs
@@ -384,7 +384,7 @@ pub fn BarChart(props: BarChartProps) -> Element {
                         dy: "{text.y}",
                         text_anchor: "{text.anchor}",
                         class: "{props.class_bar_label}",
-                        alignment_baseline: "{text.baseline}",
+                        dominant_baseline: "{text.baseline}",
                         "{bar_label}"
                     }
                 },
@@ -435,7 +435,7 @@ pub fn BarChart(props: BarChartProps) -> Element {
                                 dy: "{text.y}",
                                 text_anchor: "{text.anchor}",
                                 class: "{props.class_grid_label}",
-                                alignment_baseline: "{text.baseline}",
+                                dominant_baseline: "{text.baseline}",
                                 "{label}"
                             }
                         }

--- a/src/charts/line.rs
+++ b/src/charts/line.rs
@@ -338,7 +338,7 @@ pub fn LineChart(props: LineChartProps) -> Element {
                                 dy: "{text.y}",
                                 text_anchor: "{text.anchor}",
                                 class: "{props.class_grid_label}",
-                                alignment_baseline: "{text.baseline}",
+                                dominant_baseline: "{text.baseline}",
                                 "{label}"
                             }
                         }

--- a/src/charts/pie.rs
+++ b/src/charts/pie.rs
@@ -241,7 +241,7 @@ pub fn PieChart(props: PieChartProps) -> Element {
                                             dy: "{position.y}",
                                             text_anchor: "middle",
                                             class: "{props.class_label}",
-                                            alignment_baseline: "middle",
+                                            dominant_baseline: "middle",
                                             "{label}"
                                         }
                                     })
@@ -268,7 +268,7 @@ pub fn PieChart(props: PieChartProps) -> Element {
                                             dy: "{position.y}",
                                             text_anchor: "middle",
                                             class: "{props.class_label}",
-                                            alignment_baseline: "middle",
+                                            dominant_baseline: "middle",
                                             "{label}"
                                         }
                                     })


### PR DESCRIPTION
Replace use of `alignment_baseline` with `dominant_baseline` since it [isn't supported in Firefox](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/alignment-baseline#browser_compatibility).

# Label alignment in Chrome (tested in Brave)

<img width="1887" height="1205" alt="Chrome" src="https://github.com/user-attachments/assets/50ac1bd5-1550-4bb3-bf79-83e973db7ca3" />

# Label alignment in Firefox before change (tested in Zen)

<img width="1929" height="1193" alt="Before" src="https://github.com/user-attachments/assets/1a87df41-4218-4c81-8d7f-deb5a94ba7db" />

# Label alignment in Firefox after change (tested in Zen)

<img width="1929" height="1226" alt="After" src="https://github.com/user-attachments/assets/37024fd4-8e0c-4fab-82f8-ace8c91aebfd" />
