### PR TITLE
refactor: replace unsafe to_int_unchecked with safe cast

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -385,7 +385,7 @@ impl<'a> AxisBuilder<'a> {
 
             let range = max - min;
             debug!("range: {} min: {}, max: {}", range, min, max);
-            let steps = unsafe { (range / step).round().to_int_unchecked::<i32>() + 1 };
+            let steps = (range / step).round() as i32 + 1;
             debug!("steps: {}", steps);
 
             Axis {


### PR DESCRIPTION
## Description

This PR replaces an unnecessary `unsafe` block with a safe cast operation in the grid axis calculation.

## Changes

- Replaced `unsafe { (range / step).round().to_int_unchecked::<i32>() + 1 }` with `(range / step).round() as i32 + 1`
- Location: `src/grid.rs`, line 388

## Rationale

The `to_int_unchecked()` method is unsafe and requires guarantees that the float value is within the valid range for `i32`. However, in this case:

1. The value is already rounded using `.round()`, ensuring it's a whole number
2. A safe `as i32` cast provides the same functionality with proper bounds checking
3. This removes unnecessary unsafe code without sacrificing performance or correctness